### PR TITLE
detele button added to the single project page

### DIFF
--- a/src/components/Delete/ProjectDelete.js
+++ b/src/components/Delete/ProjectDelete.js
@@ -1,0 +1,32 @@
+import React from 'react'
+import { Btn } from './ProjectDeleteStyles'
+import PropTypes from 'prop-types'
+import { GET_LOCAL_TOKEN, PROJECT_DELETE } from '../../endpoints'
+import { useRouter } from 'next/router'
+import useFetch from '../../hooks/useFetch'
+
+const ProjectDelete = ({ id }) => {
+  const router = useRouter()
+  const { request } = useFetch()
+
+  const handleDelete = async () => {
+    const confirmation = confirm(
+      'Tem certeza que deseja prosseguir com essa ação?'
+    )
+    if (confirmation) {
+      const token = GET_LOCAL_TOKEN()
+      const { url, options } = PROJECT_DELETE(id, token)
+
+      await request(url, options)
+      router.push('/')
+    }
+  }
+
+  return <Btn onClick={handleDelete}>Excluir</Btn>
+}
+
+export default ProjectDelete
+
+ProjectDelete.propTypes = {
+  id: PropTypes.number
+}

--- a/src/components/Delete/ProjectDeleteStyles.js
+++ b/src/components/Delete/ProjectDeleteStyles.js
@@ -1,0 +1,14 @@
+import styled from 'styled-components'
+
+export const Btn = styled.button`
+  border: none;
+  border-radius: 20px;
+  box-shadow: 0 0 0 2px #eeeeee;
+  background: #fbfbfb;
+  padding: 0.5rem 1rem;
+  color: #dddddd;
+  cursor: pointer;
+  position: absolute;
+  top: 20px;
+  right: 20px;
+`

--- a/src/components/Helpers/Layout.js
+++ b/src/components/Helpers/Layout.js
@@ -26,6 +26,7 @@ export const Layout = styled.section`
   min-height: calc(100vh - 8.8rem - 6.8rem - 5.5rem);
   margin: ${({ margin }) => margin};
   padding: ${({ padding }) => padding};
+  position: ${({ position }) => position};
 
   ${props =>
     props.fromLeft &&

--- a/src/endpoints.js
+++ b/src/endpoints.js
@@ -84,3 +84,15 @@ export const USER_GET = token => {
     }
   }
 }
+
+export const PROJECT_DELETE = (id, token) => {
+  return {
+    url: `${baseUrl}/api/project/${id}`,
+    options: {
+      method: 'DELETE',
+      headers: {
+        Authorization: 'Bearer ' + token
+      }
+    }
+  }
+}

--- a/src/pages/projects/[id].js
+++ b/src/pages/projects/[id].js
@@ -10,8 +10,9 @@ import Iframe from '../../components/Iframe/Iframe'
 import useMedia from '../../hooks/useMedia'
 import Loader from '../../components/Helpers/Loader/Loader'
 import PageHead from '../../components/Helpers/Head'
+import ProjectDelete from '../../components/Delete/ProjectDelete'
 
-const Project = ({ data }) => {
+const Project = ({ data, login }) => {
   const router = useRouter()
   const [technologies, setTechnologies] = useState([])
   const width = useMedia('(max-width: 50em)')
@@ -51,8 +52,10 @@ const Project = ({ data }) => {
           align="center"
           direction="column"
           padding="5.2rem"
+          position="relative"
           fromLeft
         >
+          {login && <ProjectDelete id={data.id} />}
           <Title text={data.title} />
           <Description>{data.content}</Description>
           <Layout
@@ -108,5 +111,6 @@ export const getStaticProps = async ({ params }) => {
 export default Project
 
 Project.propTypes = {
-  data: PropTypes.object.isRequired
+  data: PropTypes.object.isRequired,
+  login: PropTypes.bool
 }


### PR DESCRIPTION
A button that deletes posts of the API was added to the single project page. Now the admin can delete projects directly from the website. The button is only available if the admin is logged in.